### PR TITLE
Metadata generation & updated documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/google-datacatalog-kafka-connector/README.md
+++ b/google-datacatalog-kafka-connector/README.md
@@ -17,19 +17,32 @@ TBA: widgets
 
 <!-- TOC -->
 
-- [google-datacatalog-kafka-connector](#google-datacatalog-kafka-connector)
-  - [Table of Contents](#table-of-contents)
-  - [1. Installation](#1-installation)
-    - [1.1. Mac/Linux](#11-maclinux)
-    - [1.2. Windows](#12-windows)
-  - [2. Install from source](#2-install-from-source)
-    - [2.1. Get the code](#21-get-the-code)
-    - [2.2. Virtualenv](#22-virtualenv)
-  - [3. Developer environment](#3-developer-environment)
-    - [3.1. Install and run YAPF formatter](#31-install-and-run-yapf-formatter)
-    - [3.2. Install and run Flake8 linter](#32-install-and-run-flake8-linter)
-    - [3.3. Install the package in editable mode (i.e. setuptools “develop mode”)](#33-install-the-package-in-editable-mode-ie-setuptools-develop-mode)
-    - [3.4. Run the unit tests](#34-run-the-unit-tests)
+   * [google-datacatalog-kafka-connector](#google-datacatalog-kafka-connector)
+      * [Table of Contents](#table-of-contents)
+      * [1. Installation](#1-installation)
+         * [1.1. Mac/Linux](#11-maclinux)
+         * [1.2. Windows](#12-windows)
+         * [1.3. Install from source](#13-install-from-source)
+            * [1.3.1. Get the code from the repository](#131-get-the-code-from-the-repository)
+            * [1.3.2. Create and activate a <em>virtualenv</em>](#132-create-and-activate-a-virtualenv)
+            * [1.3.3. Install the library](#133-install-the-library)
+      * [2. Environment setup](#2-environment-setup)
+         * [2.1. Auth credentials](#21-auth-credentials)
+            * [2.1.1. Create a service account and grant it below roles](#211-create-a-service-account-and-grant-it-below-roles)
+            * [2.1.2. Download a JSON key and save it as](#212-download-a-json-key-and-save-it-as)
+         * [2.2. Set environment variables](#22-set-environment-variables)
+      * [3. Run entry point](#3-run-entry-point)
+         * [3.1. Run Python entry point](#31-run-python-entry-point)
+      * [4. Scripts inside tools](#4-scripts-inside-tools)
+         * [4.1. Run clean up](#41-run-clean-up)
+      * [5. Developer environment](#5-developer-environment)
+         * [5.1. Install and run YAPF formatter](#51-install-and-run-yapf-formatter)
+         * [5.2. Install and run Flake8 linter](#52-install-and-run-flake8-linter)
+         * [5.3. Install the package in editable mode (i.e. setuptools “develop mode”)](#53-install-the-package-in-editable-mode-ie-setuptools-develop-mode)
+         * [5.4. Run the unit tests](#54-run-the-unit-tests)
+      * [6. Metrics](#6-metrics)
+      * [7. Troubleshooting](#7-troubleshooting)
+
 
 <!-- tocstop -->
 
@@ -43,7 +56,7 @@ dependencies and versions, and indirectly permissions.
 
 With [virtualenv][1], it's possible to install this library without needing system
 install permissions, and without clashing with the installed system
-dependencies. Make sure you use Python 3.6+.
+dependencies. Make sure you use Python 3.6 or Python 3.7.
 
 
 ### 1.1. Mac/Linux
@@ -65,21 +78,15 @@ virtualenv --python python3.6 <your-env>
 <your-env>\Scripts\pip.exe install google-datacatalog-kafka-connector
 ```
 
-## 2. Install from source
+### 1.3. Install from source
 
-### 2.1. Get the code from the repository
+#### 1.3.1. Get the code from the repository
 
 ````bash
 TBA
 ````
 
-### 2.2. Virtualenv
-
-Using *virtualenv* is optional, but strongly recommended.
-
-##### 2.2.1. Install Python 3.6
-
-##### 2.2.2. Create and activate a *virtualenv*
+#### 1.3.2. Create and activate a *virtualenv*
 
 ```bash
 pip3 install virtualenv
@@ -87,15 +94,69 @@ virtualenv --python python3.6 <your-env>
 source <your-env>/bin/activate
 ```
 
-##### 2.2.3. Install
+#### 1.3.3. Install the library
 
 ```bash
 pip install .
 ```
 
-## 3. Developer environment
+## 2. Environment setup
 
-### 3.1. Install and run YAPF formatter
+### 2.1. Auth credentials
+
+#### 2.1.1. Create a service account and grant it below roles
+
+- Data Catalog Admin
+
+#### 2.1.2. Download a JSON key and save it as
+- `<YOUR-CREDENTIALS_FILES_FOLDER>/postgresql2dc-credentials.json`
+
+> Please notice this folder and file will be required in next steps.
+
+### 2.2. Set environment variables
+
+Replace below values according to your environment:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=data_catalog_credentials_file
+
+export KAFKA2DC_DATACATALOG_PROJECT_ID=google_cloud_project_id
+export KAFKA2DC_DATACATALOG_LOCATION_ID=google_cloud_location_id
+export KAFKA2DC_KAFKA_HOST=kafka_bootstrap_server
+
+```
+
+## 3. Run entry point
+
+### 3.1. Run Python entry point
+
+- Virtualenv
+
+```bash
+google-datacatalog-kafka-connector \
+--datacatalog-project-id=$KAFKA2DC_DATACATALOG_PROJECT_ID \
+--datacatalog-location-id=$KAFKA2DC_DATACATALOG_LOCATION_ID \
+--kafka-host=$KAFKA2DC_KAFKA_HOST
+```
+
+## 4. Scripts inside tools
+
+### 4.1. Run clean up
+
+```bash
+# List of projects split by comma. Can be a single value without comma
+export KAFKA2DC_DATACATALOG_PROJECT_IDS=my-project-1,my-project-2
+```
+
+```bash
+# Run the clean up
+python tools/cleanup_datacatalog.py --datacatalog-project-ids=$KAFKA2DC_DATACATALOG_PROJECT_IDS
+
+```
+
+## 5. Developer environment
+
+### 5.1. Install and run YAPF formatter
 
 ```bash
 pip install --upgrade yapf
@@ -113,23 +174,48 @@ chmod a+x pre-commit.sh
 mv pre-commit.sh .git/hooks/pre-commit
 ```
 
-### 3.2. Install and run Flake8 linter
+### 5.2. Install and run Flake8 linter
 
 ```bash
 pip install --upgrade flake8
 flake8 src tests
 ```
 
-### 3.3. Install the package in editable mode (i.e. setuptools “develop mode”)
+### 5.3. Install the package in editable mode (i.e. setuptools “develop mode”)
 
 ```bash
 pip install --editable .
 ```
 
-### 3.4. Run the unit tests
+### 5.4. Run the unit tests
 
 ```bash
 python setup.py test
 ```
+
+## 6. Metrics
+
+This execution was collected from a Kafka 2.6.0 cluster with 3 brokers populated with 1000 topics, running the kafka2datacatalog connector to ingest
+those entities into Data Catalog. This shows what the user might expect when running this connector.
+
+The following metrics are not a guarantee, they are approximations that may change depending on the environment, network and execution.
+
+
+| Metric                     | Description                                       | VALUE            |
+| ---                        | ---                                               | ---              |
+| **elapsed_time**           | Elapsed time from the execution.                  | 11 Minutes       |
+| **entries_length**         | Number of entities ingested into Data Catalog.    | 1001             |
+
+
+## 7. Troubleshooting
+
+In the case a connector execution hits Data Catalog quota limit, an error will be raised and logged with the following detailement, depending on the performed operation READ/WRITE/SEARCH: 
+```
+status = StatusCode.RESOURCE_EXHAUSTED
+details = "Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:1111111111111'."
+debug_error_string = 
+"{"created":"@1587396969.506556000", "description":"Error received from peer ipv4:172.217.29.42:443","file":"src/core/lib/surface/call.cc","file_line":1056,"grpc_message":"Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:1111111111111'.","grpc_status":8}"
+```
+For more info about Data Catalog quota, go to: [Data Catalog quota docs](https://cloud.google.com/data-catalog/docs/resources/quotas).
 
 [1]: https://virtualenv.pypa.io/en/latest/

--- a/google-datacatalog-kafka-connector/README.md
+++ b/google-datacatalog-kafka-connector/README.md
@@ -35,6 +35,7 @@ TBA: widgets
          * [3.1. Run Python entry point](#31-run-python-entry-point)
       * [4. Scripts inside tools](#4-scripts-inside-tools)
          * [4.1. Run clean up](#41-run-clean-up)
+         * [4.2 Generate random metadata for performance testing](#42-generate-random-metadata-for-performance-testing)
       * [5. Developer environment](#5-developer-environment)
          * [5.1. Install and run YAPF formatter](#51-install-and-run-yapf-formatter)
          * [5.2. Install and run Flake8 linter](#52-install-and-run-flake8-linter)
@@ -42,7 +43,6 @@ TBA: widgets
          * [5.4. Run the unit tests](#54-run-the-unit-tests)
       * [6. Metrics](#6-metrics)
       * [7. Troubleshooting](#7-troubleshooting)
-
 
 <!-- tocstop -->
 
@@ -153,6 +153,24 @@ export KAFKA2DC_DATACATALOG_PROJECT_IDS=my-project-1,my-project-2
 python tools/cleanup_datacatalog.py --datacatalog-project-ids=$KAFKA2DC_DATACATALOG_PROJECT_IDS
 
 ```
+
+### 4.2 Generate random metadata for performance testing
+
+You can use tools/metadata-generator.py to generate random topics on a Kafka cluster
+```bash
+# List of bootstrap.servers
+export KAFKA2DC_KAFKA_HOST=kafka_bootstrap_server
+```
+
+The only required argument is --kafka-host, the rest is optional
+
+```bash
+# Run the metadata generator
+python tools/metadata_generator.py --kafka-host=$KAFKA2DC_KAFKA_HOST \
+--number-topics <number of topics to generate, 1000 by default> \
+--max-replication-factor <number> --max-partitions <number> 
+```
+
 
 ## 5. Developer environment
 

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/metadata_constants.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/metadata_constants.py
@@ -1,3 +1,20 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 class MetadataConstants:
     CLUSTER_ID = "cluster_id"
     TOPICS = "topics"

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/tag_template_constants.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/tag_template_constants.py
@@ -1,3 +1,19 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from google.cloud import datacatalog_v1beta1
 
 

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/datacatalog_cli.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/datacatalog_cli.py
@@ -41,7 +41,7 @@ class DatacatalogCli():
             project_id=args.datacatalog_project_id,
             location_id=args.datacatalog_location_id,
             entry_group_id=self._get_entry_group_id(args),
-            kafka_host=self._get_host_arg(args),
+            kafka_hosts=self._get_host_arg(args),
             connection_config=self._get_connection_config(args),
             metadata_scraper=self._get_metadata_scraper(),
             enable_monitoring=args.enable_monitoring).run()

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/prepare/datacatalog_entry_factory.py
@@ -1,3 +1,19 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from google.cloud import datacatalog_v1beta1
 from google.datacatalog_connectors.commons.prepare.base_entry_factory import \
     BaseEntryFactory

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/prepare/datacatalog_tag_factory.py
@@ -1,3 +1,19 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from google.cloud import datacatalog_v1beta1
 from google.datacatalog_connectors.kafka.config import \
     MetadataConstants, TagTemplateConstants

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
@@ -57,7 +57,7 @@ class MetadataScraper:
 
     def _get_topics_metadata(self, metadata_object):
         descriptions = []
-        topic_names = metadata_object.topics.keys()
+        topic_names = list(metadata_object.topics.keys())
         if self._SYSTEM_TOPIC in topic_names:
             topic_names.remove(self._SYSTEM_TOPIC)
         if len(topic_names) == 0:

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
@@ -35,7 +35,7 @@ class MetadataScraper:
 
     def get_metadata(self):
         try:
-            raw_metadata = self._admin_client.list_topics(timeout=20)
+            raw_metadata = self._admin_client.list_topics(timeout=10)
             cluster_metadata = self._get_cluster_metadata(raw_metadata)
             topics_metadata = self._get_topics_metadata(raw_metadata)
             cluster_metadata.update(topics_metadata)

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
@@ -122,18 +122,27 @@ class MetadataScraper:
         return topic_retention_config
 
     def _get_topic_compaction_config(self, config):
-        min_compaction_lag = config['min.compaction.lag.ms'].value
-        max_compaction_lag = config['max.compaction.lag.ms'].value
-        topic_compaction_config = {
-            MetadataConstants.MIN_COMPACTION_LAG:
-                int(min_compaction_lag),
-            MetadataConstants.MIN_COMPACTION_LAG_TEXT:
-                MetadataValuesConverter.get_human_readable_duration_value(
-                    min_compaction_lag),
-            MetadataConstants.MAX_COMPACTION_LAG:
-                int(max_compaction_lag),
-            MetadataConstants.MAX_COMPACTION_LAG_TEXT:
-                MetadataValuesConverter.get_human_readable_duration_value(
-                    max_compaction_lag)
-        }
+        topic_compaction_config = {}
+        min_compaction_lag_entry = config.get('min.compaction.lag.ms')
+        if min_compaction_lag_entry is not None:
+            min_compaction_lag = config['min.compaction.lag.ms'].value
+            topic_compaction_config.update({
+                MetadataConstants.MIN_COMPACTION_LAG:
+                    int(min_compaction_lag),
+                MetadataConstants.MIN_COMPACTION_LAG_TEXT:
+                    MetadataValuesConverter.get_human_readable_duration_value(
+                        min_compaction_lag)
+            })
+
+        max_compaction_lag_entry = config.get('max.compaction.lag.ms')
+        if max_compaction_lag_entry is not None:
+            max_compaction_lag = config['max.compaction.lag.ms'].value
+            topic_compaction_config.update({
+                MetadataConstants.MAX_COMPACTION_LAG:
+                    int(max_compaction_lag),
+                MetadataConstants.MAX_COMPACTION_LAG_TEXT:
+                    MetadataValuesConverter.get_human_readable_duration_value(
+                        max_compaction_lag)
+            })
+
         return topic_compaction_config

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
@@ -1,3 +1,19 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import time
 import confluent_kafka

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
@@ -55,6 +55,8 @@ class MetadataScraper:
 
     def _get_topics_metadata(self, metadata_object):
         topic_names = metadata_object.topics.keys()
+        if len(topic_names) == 0:
+            raise ValueError('There are no topics in the given cluster')
         descriptions = []
         config_resources = [
             ConfigResource(confluent_kafka.admin.RESOURCE_TOPIC, topic_name)

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_values_converter.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_values_converter.py
@@ -1,3 +1,19 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dateutil.relativedelta import relativedelta
 
 

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/sync/datacatalog_synchronizer.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/sync/datacatalog_synchronizer.py
@@ -35,7 +35,7 @@ class DataCatalogSynchronizer:
                  project_id,
                  location_id,
                  entry_group_id,
-                 kafka_host,
+                 kafka_hosts,
                  connection_config,
                  metadata_scraper,
                  enable_monitoring=None):
@@ -43,7 +43,7 @@ class DataCatalogSynchronizer:
         self.__metadata_scraper = metadata_scraper
         self.__project_id = project_id
         self.__location_id = location_id
-        self.__kafka_host = kafka_host
+        self.__kafka_hosts = kafka_hosts
         self.__connection_config = connection_config
         self.__task_id = uuid.uuid4().hex[:8]
         self.__metrics_processor = metrics_processor.MetricsProcessor(
@@ -59,7 +59,7 @@ class DataCatalogSynchronizer:
 
         client = self._create_client()
         metadata = self.__metadata_scraper(client,
-                                           self.__kafka_host).get_metadata()
+                                           self.__kafka_hosts).get_metadata()
 
         self._log_metadata(metadata)
 
@@ -84,7 +84,7 @@ class DataCatalogSynchronizer:
         return self.__task_id
 
     def _create_client(self):
-        connection_config = {'bootstrap.servers': self.__kafka_host}
+        connection_config = {'bootstrap.servers': self.__kafka_hosts}
         client = AdminClient(connection_config)
         return client
 
@@ -134,9 +134,9 @@ class DataCatalogSynchronizer:
             self.__create_tag_factory(), tag_templates_dict)
 
     def __create_entry_factory(self):
+        first_host = self.__kafka_hosts.split(',')[0]
         return self._get_entry_factory()(self.__project_id, self.__location_id,
-                                         self.__kafka_host,
-                                         self.__entry_group_id)
+                                         first_host, self.__entry_group_id)
 
     def __create_tag_factory(self):
         return self._get_tag_factory()()

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/sync/datacatalog_synchronizer.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/sync/datacatalog_synchronizer.py
@@ -1,3 +1,19 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import uuid
 

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/prepare/assembled_entry_factory_test.py
@@ -1,3 +1,19 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import unittest
 import mock

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/prepare/datacatalog_entry_factory_test.py
@@ -1,3 +1,19 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import unittest
 import mock

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/prepare/datacatalog_tag_template_factory_test.py
@@ -1,3 +1,19 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 
 from google.datacatalog_connectors.kafka.config import TagTemplateConstants

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/scrape/metadata_scraper_test.py
@@ -50,3 +50,13 @@ class MetadataScraperTestCase(unittest.TestCase):
             self.__MODULE_PATH, 'test_metadata_one_topic.json')
         self.maxDiff = None
         self.assertEqual(metadata, expected_metadata)
+
+    def test_scrape_cluster_without_topics_should_return_cluster_metadata(
+            self):
+        kafka_admin_client = test_utils.FakeKafkaAdminClientEmptyCluster()
+        scraper = MetadataScraper(kafka_admin_client, self.__HOST)
+        metadata = scraper.get_metadata()
+        expected_metadata = utils.Utils.convert_json_to_object(
+            self.__MODULE_PATH, 'test_metadata_no_topics.json')
+        self.maxDiff = None
+        self.assertEqual(metadata, expected_metadata)

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/test_data/test_metadata_no_topics.json
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/test_data/test_metadata_no_topics.json
@@ -1,0 +1,6 @@
+{
+  "bootstrap_server": "fake_host",
+  "cluster_id" : "1234",
+  "num_brokers": 2,
+  "topics": []
+}

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/test_utils/__init__.py
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/test_utils/__init__.py
@@ -15,9 +15,10 @@
 # limitations under the License.
 
 from .test_utils import FakeDataCatalogEntryFactory,\
-    FakeKafkaAdminClient,\
+    FakeKafkaAdminClient, FakeKafkaAdminClientEmptyCluster,\
     get_test_topic_entry, get_test_cluster_entry,\
     mock_parse_args
 
 __all__ = ('FakeDataCatalogEntryFactory', 'FakeKafkaAdminClient',
-           'get_test_topic_entry', 'get_test_cluster_entry', 'mock_parse_args')
+           'get_test_topic_entry', 'get_test_cluster_entry', 'mock_parse_args',
+           'FakeKafkaAdminClientEmptyCluster')

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/test_utils/test_utils.py
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/test_utils/test_utils.py
@@ -32,11 +32,24 @@ class FakeDataCatalogEntryFactory(DataCatalogEntryFactory):
         return entry_id, entry
 
 
+class FakeKafkaAdminClientEmptyCluster(mock.MagicMock):
+
+    def list_topics(self, timeout=-1):
+        raw_metadata = ClusterMetadata()
+        raw_metadata.topics = {}
+        raw_metadata.cluster_id = "1234"
+        raw_metadata.brokers = {
+            "testBroker0": BrokerMetadata(),
+            "testBroker1": BrokerMetadata()
+        }
+        return raw_metadata
+
+
 class FakeKafkaAdminClient(mock.MagicMock):
 
     def list_topics(self, timeout=-1):
         '''
-        Mock Consumer returns a description of
+        Mock AdminClient returns a description of
         topic from test_data/test_metadata_one_topic.json
         '''
         test_topic_metadata = TopicMetadata()
@@ -47,7 +60,10 @@ class FakeKafkaAdminClient(mock.MagicMock):
         }
 
         raw_metadata = ClusterMetadata()
-        raw_metadata.topics = {"temperature": test_topic_metadata}
+        raw_metadata.topics = {
+            "temperature": test_topic_metadata,
+            "__consumer_offsets": test_topic_metadata
+        }
         raw_metadata.cluster_id = "1234"
         raw_metadata.brokers = {
             "testBroker0": BrokerMetadata(),

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/test_utils/test_utils.py
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/test_utils/test_utils.py
@@ -1,3 +1,19 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import confluent_kafka
 import mock
 from google.cloud import datacatalog_v1beta1

--- a/google-datacatalog-kafka-connector/tools/metadata_generator.py
+++ b/google-datacatalog-kafka-connector/tools/metadata_generator.py
@@ -1,3 +1,19 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import logging
 import random

--- a/google-datacatalog-kafka-connector/tools/metadata_generator.py
+++ b/google-datacatalog-kafka-connector/tools/metadata_generator.py
@@ -1,0 +1,94 @@
+import argparse
+import logging
+import random
+import sys
+import uuid
+import math
+
+from confluent_kafka.admin import AdminClient, NewTopic
+
+_BATCH_SIZE = 50
+
+_TOPIC_NAMES = [
+    'school_visits', 'personal_info_updates', 'persons_visits',
+    'employees_updates', 'companies_updates', 'goods_arrivals', 'home_events'
+]
+
+
+def create_random_metadata():
+    admin_client = AdminClient({'bootstrap.servers': args.kafka_host})
+    topic_attributes = create_new_topics_attributes()
+    new_topics = [
+        NewTopic(topic_name,
+                 num_partitions=partitions,
+                 replication_factor=replicas)
+        for topic_name, partitions, replicas in topic_attributes
+    ]
+    num_batches = math.ceil(len(new_topics) / _BATCH_SIZE)
+    for batch in range(num_batches):
+        start_idx = batch * _BATCH_SIZE
+        stop_idx = start_idx + _BATCH_SIZE
+        topics_to_create = new_topics[start_idx:stop_idx]
+        fs = admin_client.create_topics(topics_to_create, request_timeout=60.0)
+        for topic, f in fs.items():
+            try:
+                f.result()  # The result itself is None
+                print("Topic {} created".format(topic))
+            except Exception as e:
+                print("Failed to create topic {}: {}".format(topic, e))
+
+
+def get_random_partition_number():
+    return random.randint(1, args.max_partitions)
+
+
+def get_random_replication_factor():
+    return random.randint(1, args.max_replication_factor)
+
+
+def get_random_topic_name():
+    return random.choice(_TOPIC_NAMES)
+
+
+def create_new_topics_attributes():
+    topic_attributes = []
+    for i in range(args.number_topics):
+        # for i in range(3):
+        topic_name = get_random_topic_name() + uuid.uuid4().hex[:8]
+        num_partitions = get_random_partition_number()
+        replication_factor = get_random_replication_factor()
+        topic_attributes.append(
+            (topic_name, num_partitions, replication_factor))
+
+    return topic_attributes
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Command line generate random metadata into kafka')
+    parser.add_argument(
+        '--kafka-host',
+        help='Your kafka bootstrap.servers configuration, required',
+        required=True)
+    parser.add_argument('--number-topics',
+                        help='Number of topics to create',
+                        type=int,
+                        default=1000)
+    parser.add_argument(
+        '--max-replication-factor',
+        help='Maximum replication factor for newly created topics, '
+        'should be no less than number of brokers on your cluster',
+        type=int,
+        default=1)
+    parser.add_argument('--max-partitions',
+                        help='Maximum partitions number for generated topics',
+                        type=int,
+                        default=1)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    # Enable logging
+    logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+    create_random_metadata()


### PR DESCRIPTION
This extension contains two parts:

1. Added script to generate 1000 topics in Kafka, for end-to-end testing purposes.
2. Updated README with information regarding running the connector and metrics

**How to test the entire connector**
1. Download kafka, start zookeeper, start brokers (I have 3 brokers, but you could have more or less)
2. Run metadata_generator.py script to generate 1000 random topics on you cluster
3. Setup the connector as described in README
4. Run the connector