### PR TITLE
Intergrate schema registry

### DIFF
--- a/google-datacatalog-kafka-connector/README.md
+++ b/google-datacatalog-kafka-connector/README.md
@@ -128,6 +128,7 @@ export KAFKA2DC_KAFKA_HOST=kafka_bootstrap_server
 
 Export below variables to enable optional ingestion of the schemas from the Schema Registry. 
 The url is required, the rest depends on your Schema Registry authentication setup.
+Example of the Schema Registry url: http://localhost:8081.
 
 ```bash
 # Required to connect to the Schema Registry

--- a/google-datacatalog-kafka-connector/README.md
+++ b/google-datacatalog-kafka-connector/README.md
@@ -15,34 +15,35 @@ TBA: widgets
 
 ## Table of Contents
 
-<!-- TOC -->
 
-   * [google-datacatalog-kafka-connector](#google-datacatalog-kafka-connector)
-      * [Table of Contents](#table-of-contents)
-      * [1. Installation](#1-installation)
-         * [1.1. Mac/Linux](#11-maclinux)
-         * [1.2. Windows](#12-windows)
-         * [1.3. Install from source](#13-install-from-source)
-            * [1.3.1. Get the code from the repository](#131-get-the-code-from-the-repository)
-            * [1.3.2. Create and activate a <em>virtualenv</em>](#132-create-and-activate-a-virtualenv)
-            * [1.3.3. Install the library](#133-install-the-library)
-      * [2. Environment setup](#2-environment-setup)
-         * [2.1. Auth credentials](#21-auth-credentials)
-            * [2.1.1. Create a service account and grant it below roles](#211-create-a-service-account-and-grant-it-below-roles)
-            * [2.1.2. Download a JSON key and save it as](#212-download-a-json-key-and-save-it-as)
-         * [2.2. Set environment variables](#22-set-environment-variables)
-      * [3. Run entry point](#3-run-entry-point)
-         * [3.1. Run Python entry point](#31-run-python-entry-point)
-      * [4. Scripts inside tools](#4-scripts-inside-tools)
-         * [4.1. Run clean up](#41-run-clean-up)
-         * [4.2 Generate random metadata for performance testing](#42-generate-random-metadata-for-performance-testing)
-      * [5. Developer environment](#5-developer-environment)
-         * [5.1. Install and run YAPF formatter](#51-install-and-run-yapf-formatter)
-         * [5.2. Install and run Flake8 linter](#52-install-and-run-flake8-linter)
-         * [5.3. Install the package in editable mode (i.e. setuptools “develop mode”)](#53-install-the-package-in-editable-mode-ie-setuptools-develop-mode)
-         * [5.4. Run the unit tests](#54-run-the-unit-tests)
-      * [6. Metrics](#6-metrics)
-      * [7. Troubleshooting](#7-troubleshooting)
+<!-- toc -->
+
+- [1. Installation](#1-installation)
+  * [1.1. Mac/Linux](#11-maclinux)
+  * [1.2. Windows](#12-windows)
+  * [1.3. Install from source](#13-install-from-source)
+    + [1.3.1. Get the code from the repository](#131-get-the-code-from-the-repository)
+    + [1.3.2. Create and activate a *virtualenv*](#132-create-and-activate-a-virtualenv)
+    + [1.3.3. Install the library](#133-install-the-library)
+- [2. Environment setup](#2-environment-setup)
+  * [2.1. Auth credentials](#21-auth-credentials)
+    + [2.1.1. Create a service account and grant it below roles](#211-create-a-service-account-and-grant-it-below-roles)
+    + [2.1.2. Download a JSON key and save it as](#212-download-a-json-key-and-save-it-as)
+  * [2.2. Set environment variables](#22-set-environment-variables)
+- [3. Run entry point](#3-run-entry-point)
+  * [3.1. Run Python entry point](#31-run-python-entry-point)
+- [4. Schema Registry Integration](#4-schema-registry-integration)
+  * [4.1 Run the connector with Schema Registry integration feature](#41-run-the-connector-with-schema-registry-integration-feature)
+- [5. Scripts inside tools](#5-scripts-inside-tools)
+  * [5.1. Run clean up](#51-run-clean-up)
+  * [5.2 Generate random metadata for performance testing](#52-generate-random-metadata-for-performance-testing)
+- [6. Developer environment](#6-developer-environment)
+  * [6.1. Install and run YAPF formatter](#61-install-and-run-yapf-formatter)
+  * [6.2. Install and run Flake8 linter](#62-install-and-run-flake8-linter)
+  * [6.3. Install the package in editable mode (i.e. setuptools “develop mode”)](#63-install-the-package-in-editable-mode-ie-setuptools-develop-mode)
+  * [6.4. Run the unit tests](#64-run-the-unit-tests)
+- [7. Metrics](#7-metrics)
+- [8. Troubleshooting](#8-troubleshooting)
 
 <!-- tocstop -->
 
@@ -126,34 +127,12 @@ export KAFKA2DC_KAFKA_HOST=kafka_bootstrap_server
 
 ```
 
-Export below variables to enable optional ingestion of the schemas from the Schema Registry. 
-The url is required, the rest depends on your Schema Registry authentication setup. 
-Read more about that [here] (https://docs.confluent.io/current/schema-registry/security/index.html).
-Example of the Schema Registry url: http://localhost:8081. 
-
-```bash
-# Required to connect to the Schema Registry
-
-export KAFKA2DC_SCHEMA_REGISTRY_URL=url/to/schema/registry
-
-# All the following are optional and depend on your Schema Registry authentication setup
-
-export KAFKA2DC_SCHEMA_REGISTRY_SSL_CA_LOCATION=path_to_CA_certificate_file
-export KAFKA2DC_SCHEMA_REGISTRY_SSL_CERT_LOCATION=path_to_public_key
-export KAFKA2DC_SCHEMA_REGISTRY_SSL_KEY_LOCATION=path_to_private_key
-
-# Client HTTP credentials in the form of username:password for the Schema Registry
-
-export KAFKA2DC_SCHEMA_REGISTRY_AUTH_USER_INFO=username:password
-```
 
 ## 3. Run entry point
 
 ### 3.1. Run Python entry point
 
-Arguments related to the Schema Registry are optional and should be provided only if you want the schema data to be
-ingested in the Data Catalog. In this case, --schema-registry-url is required, the rest depends on your 
-authentication setup.
+To make use of the Schema Registry Integration, please run the connector as descibed in [4. Schema Registry Integration](#4-schema-registry-integration)
 
 - Virtualenv
 
@@ -162,18 +141,60 @@ google-datacatalog-kafka-connector \
 --datacatalog-project-id=$KAFKA2DC_DATACATALOG_PROJECT_ID \
 --datacatalog-location-id=$KAFKA2DC_DATACATALOG_LOCATION_ID \
 --kafka-host=$KAFKA2DC_KAFKA_HOST \
---schema-registry-url=$KAFKA2DC_SCHEMA_REGISTRY_URL \
---schema-registry-ssl-ca-location=$KAFKA2DC_SCHEMA_REGISTRY_SSL_CA_LOCATION \
---schema-registry-ssl-cert-location=$KAFKA2DC_SCHEMA_REGISTRY_SSL_CERT_LOCATION \
---schema-registry-ssl-key-location=$KAFKA2DC_SCHEMA_REGISTRY_SSL_KEY_LOCATION \
---schema-registry-auth-user-info=$KAFKA2DC_SCHEMA_REGISTRY_AUTH_USER_INFO \
 --service-account-path=$GOOGLE_APPLICATION_CREDENTIALS
 
 ```
 
-## 4. Scripts inside tools
+## 4. Schema Registry Integration
 
-### 4.1. Run clean up
+If you use Confluent Schema Registry there is a possibility to scrape schemas for the topics and store them in the Data Catalog. 
+Please read more about Schema Management with Schema Registry in [the official documentation] (https://docs.confluent.io/current/schema-registry/index.html).
+!Attn! Currently, this connector supports only scraping of the schemas that follow the default [TopicNameStrategy] (https://docs.confluent.io/current/schema-registry/serdes-develop/index.html#sr-schemas-subject-name-strategy)
+in naming subjects. It means, that subject names are derived from the toipc names: topic `myTopic` can correspond to subjects `myTopic-key` and `myTopic-value`.
+
+To use Schema Registry integration, you have to run the connector with arguments, giving access to your Schema Registry. 
+Read more about [Schema Registry authentification] (https://docs.confluent.io/current/schema-registry/security/index.html).
+In case you use the authentification procedure that is not currently supported by this connector, please file a feature request.
+
+| Argument                                       | Description                                                                              | Mandatory                                 |
+| ---                                            | ---                                                                                      | ---                                       |
+| **--schema-registry-url**                      | Url of the running Schema Registry. <br> Example: http://localhost:8081                  | Yes                                       |
+| **--schema-registry-ssl-ca-location**          | Path to CA certificate file used to verify <br> the Schema Registry’s private key        | Only if needed <br> for authentification  |
+| **--schema-registry-ssl-cert-location**        | Path to client’s public key (PEM) <br> used for authentication.                          | Only if needed <br> for authentification  |
+| **--schema-registry-ssl-key-location**         | Path to client’s private key (PEM) <br> used for authentication.                         | Only if needed <br> for authentification  |
+| **--schema-registry-auth-user-info**           | Client HTTP credentials in the form of <br> username:password for the Schema Registry    | Only if needed <br> for authentification  |
+
+You can store the values of the arguments in the environment variables:
+
+```bash
+export KAFKA2DC_SCHEMA_REGISTRY_URL=url/to/schema/registry
+export KAFKA2DC_SCHEMA_REGISTRY_SSL_CA_LOCATION=path_to_CA_certificate_file
+export KAFKA2DC_SCHEMA_REGISTRY_SSL_CERT_LOCATION=path_to_public_key
+export KAFKA2DC_SCHEMA_REGISTRY_SSL_KEY_LOCATION=path_to_private_key
+export KAFKA2DC_SCHEMA_REGISTRY_AUTH_USER_INFO=username:password
+```
+
+### 4.1 Run the connector with Schema Registry integration feature
+
+- Virtualenv
+
+```bash
+google-datacatalog-kafka-connector \
+--datacatalog-project-id=$KAFKA2DC_DATACATALOG_PROJECT_ID \
+--datacatalog-location-id=$KAFKA2DC_DATACATALOG_LOCATION_ID \
+--kafka-host=$KAFKA2DC_KAFKA_HOST \
+--service-account-path=$GOOGLE_APPLICATION_CREDENTIALS \
+--schema-registry-url=$KAFKA2DC_SCHEMA_REGISTRY_URL \
+--schema-registry-ssl-ca-location=$KAFKA2DC_SCHEMA_REGISTRY_SSL_CA_LOCATION \
+--schema-registry-ssl-cert-location=$KAFKA2DC_SCHEMA_REGISTRY_SSL_CERT_LOCATION \
+--schema-registry-ssl-key-location=$KAFKA2DC_SCHEMA_REGISTRY_SSL_KEY_LOCATION \
+--schema-registry-auth-user-info=$KAFKA2DC_SCHEMA_REGISTRY_AUTH_USER_INFO 
+```
+
+
+## 5. Scripts inside tools
+
+### 5.1. Run clean up
 
 ```bash
 # List of projects split by comma. Can be a single value without comma
@@ -186,7 +207,7 @@ python tools/cleanup_datacatalog.py --datacatalog-project-ids=$KAFKA2DC_DATACATA
 
 ```
 
-### 4.2 Generate random metadata for performance testing
+### 5.2 Generate random metadata for performance testing
 
 You can use tools/metadata-generator.py to generate random topics on a Kafka cluster
 ```bash
@@ -204,9 +225,9 @@ python tools/metadata_generator.py --kafka-host=$KAFKA2DC_KAFKA_HOST \
 ```
 
 
-## 5. Developer environment
+## 6. Developer environment
 
-### 5.1. Install and run YAPF formatter
+### 6.1. Install and run YAPF formatter
 
 ```bash
 pip install --upgrade yapf
@@ -224,26 +245,26 @@ chmod a+x pre-commit.sh
 mv pre-commit.sh .git/hooks/pre-commit
 ```
 
-### 5.2. Install and run Flake8 linter
+### 6.2. Install and run Flake8 linter
 
 ```bash
 pip install --upgrade flake8
 flake8 src tests
 ```
 
-### 5.3. Install the package in editable mode (i.e. setuptools “develop mode”)
+### 6.3. Install the package in editable mode (i.e. setuptools “develop mode”)
 
 ```bash
 pip install --editable .
 ```
 
-### 5.4. Run the unit tests
+### 6.4. Run the unit tests
 
 ```bash
 python setup.py test
 ```
 
-## 6. Metrics
+## 7. Metrics
 
 This execution was collected from a Kafka 2.6.0 cluster with 3 brokers populated with 1000 topics, running the kafka2datacatalog connector to ingest
 those entities into Data Catalog. This shows what the user might expect when running this connector.
@@ -257,7 +278,7 @@ The following metrics are not a guarantee, they are approximations that may chan
 | **entries_length**         | Number of entities ingested into Data Catalog.    | 1001             |
 
 
-## 7. Troubleshooting
+## 8. Troubleshooting
 
 In the case a connector execution hits Data Catalog quota limit, an error will be raised and logged with the following detailement, depending on the performed operation READ/WRITE/SEARCH: 
 ```

--- a/google-datacatalog-kafka-connector/README.md
+++ b/google-datacatalog-kafka-connector/README.md
@@ -126,9 +126,32 @@ export KAFKA2DC_KAFKA_HOST=kafka_bootstrap_server
 
 ```
 
+Export below variables to enable optional ingestion of the schemas from the Schema Registry. 
+The url is required, the rest depends on your Schema Registry authentication setup.
+
+```bash
+# Required to connect to the Schema Registry
+
+export KAFKA2DC_SCHEMA_REGISTRY_URL=url/to/schema/registry
+
+# All the following are optional and depend on your Schema Registry authentication setup
+
+export KAFKA2DC_SCHEMA_REGISTRY_SSL_CA_LOCATION=path_to_CA_certificate_file
+export KAFKA2DC_SCHEMA_REGISTRY_SSL_CERT_LOCATION=path_to_public_key
+export KAFKA2DC_SCHEMA_REGISTRY_SSL_KEY_LOCATION=path_to_private_key
+
+# Client HTTP credentials in the form of username:password for the Schema Registry
+
+export KAFKA2DC_SCHEMA_REGISTRY_AUTH_USER_INFO=username:password
+```
+
 ## 3. Run entry point
 
 ### 3.1. Run Python entry point
+
+Arguments related to the Schema Registry are optional and should be provided only if you want the schema data to be
+ingested in the Data Catalog. In this case, --schema-registry-url is required, the rest depends on your 
+authentication setup.
 
 - Virtualenv
 
@@ -136,7 +159,14 @@ export KAFKA2DC_KAFKA_HOST=kafka_bootstrap_server
 google-datacatalog-kafka-connector \
 --datacatalog-project-id=$KAFKA2DC_DATACATALOG_PROJECT_ID \
 --datacatalog-location-id=$KAFKA2DC_DATACATALOG_LOCATION_ID \
---kafka-host=$KAFKA2DC_KAFKA_HOST
+--kafka-host=$KAFKA2DC_KAFKA_HOST \
+--schema-registry-url=$KAFKA2DC_SCHEMA_REGISTRY_URL \
+--schema-registry-ssl-ca-location=$KAFKA2DC_SCHEMA_REGISTRY_SSL_CA_LOCATION \
+--schema-registry-ssl-cert-location=$KAFKA2DC_SCHEMA_REGISTRY_SSL_CERT_LOCATION \
+--schema-registry-ssl-key-location=$KAFKA2DC_SCHEMA_REGISTRY_SSL_KEY_LOCATION \
+--schema-registry-auth-user-info=$KAFKA2DC_SCHEMA_REGISTRY_AUTH_USER_INFO \
+--service-account-path=$GOOGLE_APPLICATION_CREDENTIALS
+
 ```
 
 ## 4. Scripts inside tools

--- a/google-datacatalog-kafka-connector/README.md
+++ b/google-datacatalog-kafka-connector/README.md
@@ -110,7 +110,7 @@ pip install .
 - Data Catalog Admin
 
 #### 2.1.2. Download a JSON key and save it as
-- `<YOUR-CREDENTIALS_FILES_FOLDER>/postgresql2dc-credentials.json`
+- `<YOUR-CREDENTIALS_FILES_FOLDER>/kafka2dc-credentials.json`
 
 > Please notice this folder and file will be required in next steps.
 

--- a/google-datacatalog-kafka-connector/README.md
+++ b/google-datacatalog-kafka-connector/README.md
@@ -127,8 +127,9 @@ export KAFKA2DC_KAFKA_HOST=kafka_bootstrap_server
 ```
 
 Export below variables to enable optional ingestion of the schemas from the Schema Registry. 
-The url is required, the rest depends on your Schema Registry authentication setup.
-Example of the Schema Registry url: http://localhost:8081.
+The url is required, the rest depends on your Schema Registry authentication setup. 
+Read more about that [here] (https://docs.confluent.io/current/schema-registry/security/index.html).
+Example of the Schema Registry url: http://localhost:8081. 
 
 ```bash
 # Required to connect to the Schema Registry

--- a/google-datacatalog-kafka-connector/setup.py
+++ b/google-datacatalog-kafka-connector/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     include_package_data=True,
     install_requires=('pandas==0.24.2', 'gcsfs',
                       'google-datacatalog-connectors-commons', 'pyYAML',
-                      'confluent-kafka'),
+                      'confluent-kafka', 'fastavro'),
     setup_requires=('pytest-runner'),
     tests_require=('mock==3.0.5', 'pytest', 'pytest-cov',
                    'google-datacatalog-connectors-commons-test'),

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/metadata_constants.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/metadata_constants.py
@@ -33,3 +33,6 @@ class MetadataConstants:
     BOOTSTRAP_SERVER = "bootstrap_server"
     TOPIC_KEY_SCHEMA = "topic_key_schema"
     TOPIC_VALUE_SCHEMA = "topic_value_schema"
+    SCHEMA_TYPE = "schema_type"
+    SCHEMA_VERSION = "schema_version"
+    SCHEMA_STRING = "schema_string"

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/metadata_constants.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/metadata_constants.py
@@ -31,3 +31,5 @@ class MetadataConstants:
     MAX_COMPACTION_LAG = "max_compaction_lag"
     MAX_COMPACTION_LAG_TEXT = "max_compaction_lag_text"
     BOOTSTRAP_SERVER = "bootstrap_server"
+    TOPIC_KEY_SCHEMA = "topic_key_schema"
+    TOPIC_VALUE_SCHEMA = "topic_value_schema"

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/tag_template_constants.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/tag_template_constants.py
@@ -93,25 +93,25 @@ class TagTemplateConstants:
             self.consumer_groups = TagTemplateField(
                 'consumer_groups', 'Consumer groups',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
-            self.physical_schema_key = TagTemplateField(
+            self.topic_keys_physical_schema = TagTemplateField(
                 'physical_schema_topic_keys', 'Topic-Key physical schema',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
-            self.schema_type_keys = TagTemplateField(
+            self.topic_keys_schema_type = TagTemplateField(
                 'schema_type_topic_keys',
                 'Type of the physical schema of topic keys',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
-            self.schema_version_keys = TagTemplateField(
+            self.topic_keys_schema_version = TagTemplateField(
                 'schema_version_topic_keys',
                 'Version of the physical schema of topic keys',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.DOUBLE)
-            self.physical_schema_value = TagTemplateField(
+            self.topic_values_physical_schema = TagTemplateField(
                 'physical_schema_topic_values', 'Topic-Value physical schema',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
-            self.schema_type_values = TagTemplateField(
+            self.topic_values_schema_type = TagTemplateField(
                 'schema_type_topic_values',
                 'Type of the physical schema of topic values',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
-            self.schema_version_values = TagTemplateField(
+            self.topic_values_schema_version = TagTemplateField(
                 'schema_version_topic_values',
                 'Version of the physical schema of topic values',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.DOUBLE)

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/tag_template_constants.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/tag_template_constants.py
@@ -94,16 +94,26 @@ class TagTemplateConstants:
                 'consumer_groups', 'Consumer groups',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
             self.physical_schema_key = TagTemplateField(
-                'physical_schema_key', 'Key physical schema',
+                'physical_schema_topic_keys', 'Topic-Key physical schema',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
+            self.schema_type_keys = TagTemplateField(
+                'schema_type_topic_keys',
+                'Type of the physical schema of topic keys',
+                datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
+            self.schema_version_keys = TagTemplateField(
+                'schema_version_topic_keys',
+                'Version of the physical schema of topic keys',
+                datacatalog_v1beta1.enums.FieldType.PrimitiveType.DOUBLE)
             self.physical_schema_value = TagTemplateField(
-                'physical_schema_value', 'Value physical schema',
+                'physical_schema_topic_values', 'Topic-Value physical schema',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
-            self.schema_type = TagTemplateField(
-                'schema_type', 'Schema type',
+            self.schema_type_values = TagTemplateField(
+                'schema_type_topic_values',
+                'Type of the physical schema of topic values',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
-            self.schema_version = TagTemplateField(
-                'schema_version', 'Schema version',
+            self.schema_version_values = TagTemplateField(
+                'schema_version_topic_values',
+                'Version of the physical schema of topic values',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.DOUBLE)
 
 

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/tag_template_constants.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/tag_template_constants.py
@@ -96,22 +96,22 @@ class TagTemplateConstants:
             self.topic_keys_physical_schema = TagTemplateField(
                 'physical_schema_topic_keys', 'Topic-Key physical schema',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
-            self.topic_keys_schema_type = TagTemplateField(
+            self.topic_keys_physical_schema_type = TagTemplateField(
                 'schema_type_topic_keys',
                 'Type of the physical schema of topic keys',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
-            self.topic_keys_schema_version = TagTemplateField(
+            self.topic_keys_physical_schema_version = TagTemplateField(
                 'schema_version_topic_keys',
                 'Version of the physical schema of topic keys',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.DOUBLE)
             self.topic_values_physical_schema = TagTemplateField(
                 'physical_schema_topic_values', 'Topic-Value physical schema',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
-            self.topic_values_schema_type = TagTemplateField(
+            self.topic_values_physical_schema_type = TagTemplateField(
                 'schema_type_topic_values',
                 'Type of the physical schema of topic values',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
-            self.topic_values_schema_version = TagTemplateField(
+            self.topic_values_physical_schema_version = TagTemplateField(
                 'schema_version_topic_values',
                 'Version of the physical schema of topic values',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.DOUBLE)

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/tag_template_constants.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/tag_template_constants.py
@@ -93,11 +93,11 @@ class TagTemplateConstants:
             self.consumer_groups = TagTemplateField(
                 'consumer_groups', 'Consumer groups',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
-            self.key_schema = TagTemplateField(
-                'key_schema', 'Key schema',
+            self.physical_schema_key = TagTemplateField(
+                'physical_schema_key', 'Key physical schema',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
-            self.value_schema = TagTemplateField(
-                'value_schema', 'Value schema',
+            self.physical_schema_value = TagTemplateField(
+                'physical_schema_value', 'Value physical schema',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
 
 

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/tag_template_constants.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/tag_template_constants.py
@@ -99,6 +99,12 @@ class TagTemplateConstants:
             self.physical_schema_value = TagTemplateField(
                 'physical_schema_value', 'Value physical schema',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
+            self.schema_type = TagTemplateField(
+                'schema_type', 'Schema type',
+                datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
+            self.schema_version = TagTemplateField(
+                'schema_version', 'Schema version',
+                datacatalog_v1beta1.enums.FieldType.PrimitiveType.DOUBLE)
 
 
 class TagTemplateField:

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/tag_template_constants.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/config/tag_template_constants.py
@@ -93,8 +93,11 @@ class TagTemplateConstants:
             self.consumer_groups = TagTemplateField(
                 'consumer_groups', 'Consumer groups',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
-            self.schema = TagTemplateField(
-                'schema', 'Schema',
+            self.key_schema = TagTemplateField(
+                'key_schema', 'Key schema',
+                datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
+            self.value_schema = TagTemplateField(
+                'value_schema', 'Value schema',
                 datacatalog_v1beta1.enums.FieldType.PrimitiveType.STRING)
 
 

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/datacatalog_cli.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/datacatalog_cli.py
@@ -42,8 +42,9 @@ class DatacatalogCli():
             location_id=args.datacatalog_location_id,
             entry_group_id=self._get_entry_group_id(args),
             kafka_hosts=self._get_host_arg(args),
-            connection_config=self._get_connection_config(args),
             metadata_scraper=self._get_metadata_scraper(),
+            schema_registry_conf=self._get_schema_registry_connection_config(
+                args),
             enable_monitoring=args.enable_monitoring).run()
 
     def _get_datacatalog_synchronizer(self):
@@ -55,9 +56,21 @@ class DatacatalogCli():
     def _get_host_arg(self, args):
         return args.kafka_host
 
-    def _get_connection_config(self, args):
-        group_id = args.group_id or 'kafka2dc'
-        return {'bootstrap.servers': args.kafka_host, 'group.id': group_id}
+    def _get_schema_registry_connection_config(self, args):
+        if args.schema_registry_url is None:
+            return None
+        connection_args = {
+            'url': args.schema_registry_url,
+            'ssl.ca.location': args.schema_registry_ssl_ca_location,
+            'ssl.certificate.location': args.schema_registry_ssl_cert_location,
+            'ssl.key.location': args.schema_registry_ssl_key_location
+        }
+        provided_connection_args = {
+            arg: arg_value
+            for arg, arg_value in connection_args.items()
+            if arg_value is not None
+        }
+        return provided_connection_args
 
     def _get_entry_group_id(self, args):
         return args.datacatalog_entry_group_id or 'kafka'
@@ -80,8 +93,18 @@ class DatacatalogCli():
         parser.add_argument('--kafka-host',
                             help='Your kafka server host',
                             required=True)
-        parser.add_argument('--group-id',
-                            help='Group.id parameter for a Kafka consumer')
+        parser.add_argument('--schema-registry-url',
+                            help='Url to connect to the schema registry')
+        parser.add_argument(
+            '--schema-registry-ssl-ca-location',
+            help='File or directory path to CA '
+            'certificate(s) for verifying the Schema Registry key')
+        parser.add_argument('--schema-registry-ssl-cert-location',
+                            help='Path to client\'s public key '
+                            'used for Schema Registry authentication')
+        parser.add_argument('--schema-registry-ssl-key-location',
+                            help='Path to client\'s private key '
+                            'used for Schema Registry authentication')
         parser.add_argument('--service-account-path',
                             help='Local Service Account path '
                             '(Can be suplied as '

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/datacatalog_cli.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/datacatalog_cli.py
@@ -59,8 +59,9 @@ class DatacatalogCli():
     def _get_schema_registry_connection_config(self, args):
         if args.schema_registry_url is None:
             return None
+        url = self._normalize_schema_registry_url(args.schema_registry_url)
         connection_args = {
-            'url': args.schema_registry_url,
+            'url': url,
             'ssl.ca.location': args.schema_registry_ssl_ca_location,
             'ssl.certificate.location': args.schema_registry_ssl_cert_location,
             'ssl.key.location': args.schema_registry_ssl_key_location,
@@ -72,6 +73,11 @@ class DatacatalogCli():
             if arg_value is not None
         }
         return provided_connection_args
+
+    def _normalize_schema_registry_url(self, url):
+        if not url.startswith('http'):
+            return "".join(['http://', url])
+        return url
 
     def _get_entry_group_id(self, args):
         return args.datacatalog_entry_group_id or 'kafka'

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/datacatalog_cli.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/datacatalog_cli.py
@@ -63,7 +63,8 @@ class DatacatalogCli():
             'url': args.schema_registry_url,
             'ssl.ca.location': args.schema_registry_ssl_ca_location,
             'ssl.certificate.location': args.schema_registry_ssl_cert_location,
-            'ssl.key.location': args.schema_registry_ssl_key_location
+            'ssl.key.location': args.schema_registry_ssl_key_location,
+            'basic.auth.user.info': args.schema_registry_auth_user_info
         }
         provided_connection_args = {
             arg: arg_value
@@ -94,17 +95,19 @@ class DatacatalogCli():
                             help='Your kafka server host',
                             required=True)
         parser.add_argument('--schema-registry-url',
-                            help='Url to connect to the schema registry')
-        parser.add_argument(
-            '--schema-registry-ssl-ca-location',
-            help='File or directory path to CA '
-            'certificate(s) for verifying the Schema Registry key')
+                            help='Url to connect to the Schema Registry')
+        parser.add_argument('--schema-registry-ssl-ca-location',
+                            help='Path to CA certificate file used to verify '
+                            'the Schema Registry’s private key.')
         parser.add_argument('--schema-registry-ssl-cert-location',
-                            help='Path to client\'s public key '
-                            'used for Schema Registry authentication')
+                            help='Path to client’s public key (PEM) '
+                            'used for authentication.')
         parser.add_argument('--schema-registry-ssl-key-location',
-                            help='Path to client\'s private key '
-                            'used for Schema Registry authentication')
+                            help='Path to client’s private key (PEM) '
+                            'used for authentication.')
+        parser.add_argument('--schema-registry-auth-user-info',
+                            help='Client HTTP credentials in the form of '
+                            'username:password for the Schema Registry')
         parser.add_argument('--service-account-path',
                             help='Local Service Account path '
                             '(Can be suplied as '

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/prepare/datacatalog_tag_factory.py
@@ -83,10 +83,10 @@ class DataCatalogTagFactory:
             tag.fields[template_fields.topic_keys_physical_schema.
                        name].string_value = key_schema.get(
                            MetadataConstants.SCHEMA_STRING)
-            tag.fields[template_fields.topic_keys_schema_type.
+            tag.fields[template_fields.topic_keys_physical_schema_type.
                        name].string_value = key_schema.get(
                            MetadataConstants.SCHEMA_TYPE)
-            tag.fields[template_fields.topic_keys_schema_version.
+            tag.fields[template_fields.topic_keys_physical_schema_version.
                        name].double_value = key_schema.get(
                            MetadataConstants.SCHEMA_VERSION)
         value_schema = topic_metadata.get(MetadataConstants.TOPIC_VALUE_SCHEMA)
@@ -94,10 +94,10 @@ class DataCatalogTagFactory:
             tag.fields[template_fields.topic_values_physical_schema.
                        name].string_value = value_schema.get(
                            MetadataConstants.SCHEMA_STRING)
-            tag.fields[template_fields.topic_values_schema_type.
+            tag.fields[template_fields.topic_values_physical_schema_type.
                        name].string_value = value_schema.get(
                            MetadataConstants.SCHEMA_TYPE)
-            tag.fields[template_fields.topic_values_schema_version.
+            tag.fields[template_fields.topic_values_physical_schema_version.
                        name].double_value = value_schema.get(
                            MetadataConstants.SCHEMA_VERSION)
         return tag

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/prepare/datacatalog_tag_factory.py
@@ -80,10 +80,10 @@ class DataCatalogTagFactory:
                            MetadataConstants.MAX_COMPACTION_LAG_TEXT)
         key_schema = topic_metadata.get(MetadataConstants.TOPIC_KEY_SCHEMA)
         if key_schema:
-            tag.fields[
-                template_fields.physical_schema_key.name].string_value = key_schema
+            tag.fields[template_fields.physical_schema_key.
+                       name].string_value = key_schema
         value_schema = topic_metadata.get(MetadataConstants.TOPIC_VALUE_SCHEMA)
         if value_schema:
-            tag.fields[
-                template_fields.physical_schema_value.name].string_value = value_schema
+            tag.fields[template_fields.physical_schema_value.
+                       name].string_value = value_schema
         return tag

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/prepare/datacatalog_tag_factory.py
@@ -78,4 +78,12 @@ class DataCatalogTagFactory:
             tag.fields[template_fields.max_compaction_lag_as_text.
                        name].string_value = topic_metadata.get(
                            MetadataConstants.MAX_COMPACTION_LAG_TEXT)
+        key_schema = topic_metadata.get(MetadataConstants.TOPIC_KEY_SCHEMA)
+        if key_schema:
+            tag.fields[
+                template_fields.key_schema.name].string_value = key_schema
+        value_schema = topic_metadata.get(MetadataConstants.TOPIC_VALUE_SCHEMA)
+        if value_schema:
+            tag.fields[
+                template_fields.value_schema.name].string_value = value_schema
         return tag

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/prepare/datacatalog_tag_factory.py
@@ -81,9 +81,9 @@ class DataCatalogTagFactory:
         key_schema = topic_metadata.get(MetadataConstants.TOPIC_KEY_SCHEMA)
         if key_schema:
             tag.fields[
-                template_fields.key_schema.name].string_value = key_schema
+                template_fields.physical_schema_key.name].string_value = key_schema
         value_schema = topic_metadata.get(MetadataConstants.TOPIC_VALUE_SCHEMA)
         if value_schema:
             tag.fields[
-                template_fields.value_schema.name].string_value = value_schema
+                template_fields.physical_schema_value.name].string_value = value_schema
         return tag

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/prepare/datacatalog_tag_factory.py
@@ -80,10 +80,24 @@ class DataCatalogTagFactory:
                            MetadataConstants.MAX_COMPACTION_LAG_TEXT)
         key_schema = topic_metadata.get(MetadataConstants.TOPIC_KEY_SCHEMA)
         if key_schema:
-            tag.fields[template_fields.physical_schema_key.
-                       name].string_value = key_schema
+            tag.fields[template_fields.topic_keys_physical_schema.
+                       name].string_value = key_schema.get(
+                           MetadataConstants.SCHEMA_STRING)
+            tag.fields[template_fields.topic_keys_schema_type.
+                       name].string_value = key_schema.get(
+                           MetadataConstants.SCHEMA_TYPE)
+            tag.fields[template_fields.topic_keys_schema_version.
+                       name].double_value = key_schema.get(
+                           MetadataConstants.SCHEMA_VERSION)
         value_schema = topic_metadata.get(MetadataConstants.TOPIC_VALUE_SCHEMA)
         if value_schema:
-            tag.fields[template_fields.physical_schema_value.
-                       name].string_value = value_schema
+            tag.fields[template_fields.topic_values_physical_schema.
+                       name].string_value = value_schema.get(
+                           MetadataConstants.SCHEMA_STRING)
+            tag.fields[template_fields.topic_values_schema_type.
+                       name].string_value = value_schema.get(
+                           MetadataConstants.SCHEMA_TYPE)
+            tag.fields[template_fields.topic_values_schema_version.
+                       name].double_value = value_schema.get(
+                           MetadataConstants.SCHEMA_VERSION)
         return tag

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
@@ -103,7 +103,8 @@ class MetadataScraper:
         if 'compact' in cleanup_policy:
             topic_description.update(
                 self._get_topic_compaction_config(config_desc))
-        topic_description.update(self._get_topic_schemas(topic_name))
+        if self._schema_registry_client is not None:
+            topic_description.update(self._get_topic_schemas(topic_name))
         return topic_description
 
     def _get_topic_retention_config(self, config):

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
@@ -87,10 +87,16 @@ class MetadataScraper:
         topic_metadata = {MetadataConstants.TOPICS: descriptions}
         return topic_metadata
 
-    def _get_schema_for_topic(self, topic_name):
+    def _get_value_schema_for_topic(self, topic_name):
         subject_value = topic_name + '-value'
+        schema = self._schema_registry_client.get_latest_schema(
+            subject_value)[1]
+        return schema
+
+    def _get_key_schema_for_topic(self, topic_name):
         subject_key = topic_name + '-key'
-        # TODO
+        schema = self._schema_registry_client.get_latest_schema(subject_key)[1]
+        return schema
 
     def _assemble_topic_metadata(self, topic_name, raw_metadata, config_desc):
         num_partitions = len(raw_metadata.topics[topic_name].partitions)

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
@@ -170,13 +170,20 @@ class MetadataScraper:
         topic_schemas = {}
         subject_value = topic_name + '-value'
         subject_key = topic_name + '-key'
-        subjects = self._schema_registry_client.get_subjects()
-        if subject_value in subjects:
-            value_schema = self._schema_registry_client.get_latest_version(
-                subject_value).schema.schema_str
-            topic_schemas[MetadataConstants.TOPIC_VALUE_SCHEMA] = value_schema
-        if subject_key in subjects:
-            key_schema = self._schema_registry_client.get_latest_version(
-                subject_key).schema.schema_str
-            topic_schemas[MetadataConstants.TOPIC_KEY_SCHEMA] = key_schema
+        try:
+            subjects = self._schema_registry_client.get_subjects()
+            if subject_value in subjects:
+                value_schema = self._schema_registry_client.get_latest_version(
+                    subject_value).schema.schema_str
+                topic_schemas[
+                    MetadataConstants.TOPIC_VALUE_SCHEMA] = value_schema
+            if subject_key in subjects:
+                key_schema = self._schema_registry_client.get_latest_version(
+                    subject_key).schema.schema_str
+                topic_schemas[MetadataConstants.TOPIC_KEY_SCHEMA] = key_schema
+        except (ValueError, TypeError) as e:
+            logging.error("Failed to pull information about topic {} "
+                          "from the Schema Registry: {}".format(topic_name, e))
+            raise
+
         return topic_schemas

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
@@ -27,8 +27,6 @@ from .metadata_values_converter import MetadataValuesConverter
 
 class MetadataScraper:
 
-    _SYSTEM_TOPIC = '__consumer_offsets'
-
     def __init__(self, bootstrap_server, client, schema_registry_client=None):
         self._bootstrap_server = bootstrap_server
         self._admin_client = client

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/metadata_scraper.py
@@ -29,9 +29,10 @@ class MetadataScraper:
 
     _SYSTEM_TOPIC = '__consumer_offsets'
 
-    def __init__(self, client, bootstrap_server):
-        self._admin_client = client
+    def __init__(self, bootstrap_server, client, schema_registry_client=None):
         self._bootstrap_server = bootstrap_server
+        self._admin_client = client
+        self._schema_registry_client = schema_registry_client
 
     def get_metadata(self):
         try:
@@ -85,6 +86,11 @@ class MetadataScraper:
                 len(descriptions), end_describing - start_describing))
         topic_metadata = {MetadataConstants.TOPICS: descriptions}
         return topic_metadata
+
+    def _get_schema_for_topic(self, topic_name):
+        subject_value = topic_name + '-value'
+        subject_key = topic_name + '-key'
+        # TODO
 
     def _assemble_topic_metadata(self, topic_name, raw_metadata, config_desc):
         num_partitions = len(raw_metadata.topics[topic_name].partitions)

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/schema_registry_scraper.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/schema_registry_scraper.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from confluent_kafka.schema_registry.schema_registry_client \
+    import SchemaRegistryError
+from google.datacatalog_connectors.kafka.config.\
+    metadata_constants import MetadataConstants
+
+
+class SchemaRegistryScraper:
+
+    def __init__(self, schema_registry_client):
+        self._schema_registry_client = schema_registry_client
+        self._subjects = self._get_subjects()
+
+    def scrape_schema_metadata(self, topic_name):
+        schema_metadata = {}
+        subject_value = topic_name + '-value'
+        subject_key = topic_name + '-key'
+        try:
+            key_schema_metadata = self._get_subject_details(
+                subject_key, MetadataConstants.TOPIC_KEY_SCHEMA)
+            schema_metadata.update(key_schema_metadata)
+            value_schema_metadata = self._get_subject_details(
+                subject_value, MetadataConstants.TOPIC_VALUE_SCHEMA)
+            schema_metadata.update(value_schema_metadata)
+            return schema_metadata
+        except (ValueError, TypeError) as e:
+            logging.error("Failed to pull information about topic {} "
+                          "from the Schema Registry: {}".format(topic_name, e))
+            raise
+
+    def _get_subjects(self):
+        try:
+            subjects = self._schema_registry_client.get_subjects()
+            return subjects
+        except SchemaRegistryError as e:
+            logging.error("Failed to get list of the subjects "
+                          "from the Schema Registry {}".format(e))
+            raise
+
+    def _get_subject_details(self, subject_name, metadata_dict_key):
+        topic_schema_metadata = {}
+        try:
+            if subject_name in self._subjects:
+                registered_schema = self._schema_registry_client\
+                    .get_latest_version(subject_name)
+                schema_str = registered_schema.schema.schema_str
+                schema_version = registered_schema.version
+                schema_type = registered_schema.schema.schema_type
+                topic_schema_metadata[metadata_dict_key] = {
+                    MetadataConstants.SCHEMA_VERSION: schema_version,
+                    MetadataConstants.SCHEMA_TYPE: schema_type,
+                    MetadataConstants.SCHEMA_STRING: schema_str
+                }
+            return topic_schema_metadata
+        except (ValueError, TypeError) as e:
+            logging.error("Failed to pull information about subject {} "
+                          "from the Schema Registry: {}".format(
+                              subject_name, e))
+            raise

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/schema_registry_scraper.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/scrape/schema_registry_scraper.py
@@ -29,20 +29,20 @@ class SchemaRegistryScraper:
 
     def scrape_schema_metadata(self, topic_name):
         schema_metadata = {}
-        subject_value = topic_name + '-value'
         subject_key = topic_name + '-key'
-        try:
-            key_schema_metadata = self._get_subject_details(
-                subject_key, MetadataConstants.TOPIC_KEY_SCHEMA)
-            schema_metadata.update(key_schema_metadata)
-            value_schema_metadata = self._get_subject_details(
-                subject_value, MetadataConstants.TOPIC_VALUE_SCHEMA)
-            schema_metadata.update(value_schema_metadata)
-            return schema_metadata
-        except (ValueError, TypeError) as e:
-            logging.error("Failed to pull information about topic {} "
-                          "from the Schema Registry: {}".format(topic_name, e))
-            raise
+        subject_value = topic_name + '-value'
+
+        key_schema_metadata = self._get_subject_details(subject_key)
+        if len(key_schema_metadata) > 0:
+            schema_metadata.update(
+                {MetadataConstants.TOPIC_KEY_SCHEMA: key_schema_metadata})
+
+        value_schema_metadata = self._get_subject_details(subject_value)
+        if len(value_schema_metadata) > 0:
+            schema_metadata.update(
+                {MetadataConstants.TOPIC_VALUE_SCHEMA: value_schema_metadata})
+
+        return schema_metadata
 
     def _get_subjects(self):
         try:
@@ -53,7 +53,7 @@ class SchemaRegistryScraper:
                           "from the Schema Registry {}".format(e))
             raise
 
-    def _get_subject_details(self, subject_name, metadata_dict_key):
+    def _get_subject_details(self, subject_name):
         topic_schema_metadata = {}
         try:
             if subject_name in self._subjects:
@@ -62,7 +62,7 @@ class SchemaRegistryScraper:
                 schema_str = registered_schema.schema.schema_str
                 schema_version = registered_schema.version
                 schema_type = registered_schema.schema.schema_type
-                topic_schema_metadata[metadata_dict_key] = {
+                topic_schema_metadata = {
                     MetadataConstants.SCHEMA_VERSION: schema_version,
                     MetadataConstants.SCHEMA_TYPE: schema_type,
                     MetadataConstants.SCHEMA_STRING: schema_str

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/sync/datacatalog_synchronizer.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/sync/datacatalog_synchronizer.py
@@ -18,8 +18,8 @@ import logging
 import uuid
 
 from confluent_kafka.admin import AdminClient
-from confluent_kafka.avro.cached_schema_registry_client \
-    import CachedSchemaRegistryClient
+from confluent_kafka.schema_registry.schema_registry_client \
+    import SchemaRegistryClient
 
 from google.datacatalog_connectors.commons.cleanup \
     import datacatalog_metadata_cleaner
@@ -95,7 +95,7 @@ class DataCatalogSynchronizer:
     def _create_schema_registry_client(self):
         client = None
         if self.__schema_registry_conf is not None:
-            client = CachedSchemaRegistryClient(self.__schema_registry_conf)
+            client = SchemaRegistryClient(self.__schema_registry_conf)
         return client
 
     def __prepare_datacatalog_entries(self, metadata, tag_templates_dict):

--- a/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/sync/datacatalog_synchronizer.py
+++ b/google-datacatalog-kafka-connector/src/google/datacatalog_connectors/kafka/sync/datacatalog_synchronizer.py
@@ -18,6 +18,8 @@ import logging
 import uuid
 
 from confluent_kafka.admin import AdminClient
+from confluent_kafka.avro.cached_schema_registry_client \
+    import CachedSchemaRegistryClient
 
 from google.datacatalog_connectors.commons.cleanup \
     import datacatalog_metadata_cleaner
@@ -36,15 +38,15 @@ class DataCatalogSynchronizer:
                  location_id,
                  entry_group_id,
                  kafka_hosts,
-                 connection_config,
                  metadata_scraper,
+                 schema_registry_conf=None,
                  enable_monitoring=None):
         self.__entry_group_id = entry_group_id
         self.__metadata_scraper = metadata_scraper
         self.__project_id = project_id
         self.__location_id = location_id
         self.__kafka_hosts = kafka_hosts
-        self.__connection_config = connection_config
+        self.__schema_registry_conf = schema_registry_conf
         self.__task_id = uuid.uuid4().hex[:8]
         self.__metrics_processor = metrics_processor.MetricsProcessor(
             project_id, location_id, entry_group_id, enable_monitoring,
@@ -57,9 +59,11 @@ class DataCatalogSynchronizer:
         self._before_run()
         logging.info('\n\n==============Scrape metadata===============')
 
-        client = self._create_client()
-        metadata = self.__metadata_scraper(client,
-                                           self.__kafka_hosts).get_metadata()
+        admin_client = self._create_admin_client()
+        schema_registry_client = self._create_schema_registry_client()
+        metadata = self.__metadata_scraper(
+            self.__kafka_hosts, admin_client,
+            schema_registry_client).get_metadata()
 
         self._log_metadata(metadata)
 
@@ -83,9 +87,15 @@ class DataCatalogSynchronizer:
 
         return self.__task_id
 
-    def _create_client(self):
+    def _create_admin_client(self):
         connection_config = {'bootstrap.servers': self.__kafka_hosts}
         client = AdminClient(connection_config)
+        return client
+
+    def _create_schema_registry_client(self):
+        client = None
+        if self.__schema_registry_conf is not None:
+            client = CachedSchemaRegistryClient(self.__schema_registry_conf)
         return client
 
     def __prepare_datacatalog_entries(self, metadata, tag_templates_dict):

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/prepare/datacatalog_tag_factory_test.py
@@ -58,7 +58,17 @@ class DataCatalogTagFactoryTest(unittest.TestCase):
             MetadataConstants.MIN_COMPACTION_LAG: 100,
             MetadataConstants.MIN_COMPACTION_LAG_TEXT: "100 ms",
             MetadataConstants.MAX_COMPACTION_LAG: 172800000,
-            MetadataConstants.MAX_COMPACTION_LAG_TEXT: "2 d"
+            MetadataConstants.MAX_COMPACTION_LAG_TEXT: "2 d",
+            MetadataConstants.TOPIC_VALUE_SCHEMA: {
+                MetadataConstants.SCHEMA_STRING: "test-schema-topic-values",
+                MetadataConstants.SCHEMA_TYPE: "AVRO",
+                MetadataConstants.SCHEMA_VERSION: 9
+            },
+            MetadataConstants.TOPIC_KEY_SCHEMA: {
+                MetadataConstants.SCHEMA_STRING: "test-schema-topic-keys",
+                MetadataConstants.SCHEMA_TYPE: "AVRO",
+                MetadataConstants.SCHEMA_VERSION: 2
+            }
         }
         tag = tag_factory.make_tag_for_topic(tag_template, topic_metadata)
         self.assertEqual(3, tag.fields['num_partitions'].double_value)
@@ -76,3 +86,16 @@ class DataCatalogTagFactoryTest(unittest.TestCase):
         self.assertEqual(172800000,
                          tag.fields['max_compaction_lag_ms'].double_value)
         self.assertEqual("2 d", tag.fields['max_compaction_lag'].string_value)
+        self.assertEqual(
+            "test-schema-topic-values",
+            tag.fields['physical_schema_topic_values'].string_value)
+        self.assertEqual("AVRO",
+                         tag.fields['schema_type_topic_values'].string_value)
+        self.assertEqual(
+            9, tag.fields['schema_version_topic_values'].double_value)
+        self.assertEqual("test-schema-topic-keys",
+                         tag.fields['physical_schema_topic_keys'].string_value)
+        self.assertEqual("AVRO",
+                         tag.fields['schema_type_topic_keys'].string_value)
+        self.assertEqual(2,
+                         tag.fields['schema_version_topic_keys'].double_value)

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/scrape/metadata_scraper_test.py
@@ -32,19 +32,19 @@ class MetadataScraperTestCase(unittest.TestCase):
 
     def test_scrape_metadata_with_credentials_should_return_objects(self):
         kafka_admin_client = test_utils.FakeKafkaAdminClient()
-        scraper = MetadataScraper(kafka_admin_client, self.__HOST)
+        scraper = MetadataScraper(self.__HOST, kafka_admin_client)
         metadata = scraper.get_metadata()
         self.assertGreater(len(metadata), 0)
 
     def test_scrape_metadata_on_connection_exception_should_re_raise(self):
         test_config = {'bootstrap.servers': self.__HOST}
         admin_client = AdminClient(test_config)
-        scraper = MetadataScraper(admin_client, self.__HOST)
+        scraper = MetadataScraper(self.__HOST, admin_client)
         self.assertRaises(Exception, scraper.get_metadata)
 
     def test_scrape_metadata_should_describe_all_fields(self):
         kafka_admin_client = test_utils.FakeKafkaAdminClient()
-        scraper = MetadataScraper(kafka_admin_client, self.__HOST)
+        scraper = MetadataScraper(self.__HOST, kafka_admin_client)
         metadata = scraper.get_metadata()
         expected_metadata = utils.Utils.convert_json_to_object(
             self.__MODULE_PATH, 'test_metadata_one_topic.json')
@@ -54,7 +54,7 @@ class MetadataScraperTestCase(unittest.TestCase):
     def test_scrape_cluster_without_topics_should_return_cluster_metadata(
             self):
         kafka_admin_client = test_utils.FakeKafkaAdminClientEmptyCluster()
-        scraper = MetadataScraper(kafka_admin_client, self.__HOST)
+        scraper = MetadataScraper(self.__HOST, kafka_admin_client)
         metadata = scraper.get_metadata()
         expected_metadata = utils.Utils.convert_json_to_object(
             self.__MODULE_PATH, 'test_metadata_no_topics.json')

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/scrape/metadata_scraper_test.py
@@ -30,9 +30,21 @@ class MetadataScraperTestCase(unittest.TestCase):
     __HOST = 'fake_host'
     __MODULE_PATH = os.path.dirname(os.path.abspath(__file__))
 
-    def test_scrape_metadata_with_credentials_should_return_objects(self):
+    def test_scrape_metadata_without_schema_registry_should_return_objects(
+            self):
         kafka_admin_client = test_utils.FakeKafkaAdminClient()
-        scraper = MetadataScraper(self.__HOST, kafka_admin_client)
+        scraper = MetadataScraper(self.__HOST,
+                                  kafka_admin_client,
+                                  schema_registry_client=None)
+        metadata = scraper.get_metadata()
+        self.assertGreater(len(metadata), 0)
+
+    def test_scrape_metadata_with_schema_registry_should_return_objects(self):
+        kafka_admin_client = test_utils.FakeKafkaAdminClient()
+        kafka_schema_registry_client = test_utils.\
+            FakeKafkaSchemaRegistryClient()
+        scraper = MetadataScraper(self.__HOST, kafka_admin_client,
+                                  kafka_schema_registry_client)
         metadata = scraper.get_metadata()
         self.assertGreater(len(metadata), 0)
 
@@ -44,7 +56,10 @@ class MetadataScraperTestCase(unittest.TestCase):
 
     def test_scrape_metadata_should_describe_all_fields(self):
         kafka_admin_client = test_utils.FakeKafkaAdminClient()
-        scraper = MetadataScraper(self.__HOST, kafka_admin_client)
+        kafka_schema_registry_client = test_utils.\
+            FakeKafkaSchemaRegistryClient()
+        scraper = MetadataScraper(self.__HOST, kafka_admin_client,
+                                  kafka_schema_registry_client)
         metadata = scraper.get_metadata()
         expected_metadata = utils.Utils.convert_json_to_object(
             self.__MODULE_PATH, 'test_metadata_one_topic.json')

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/scrape/schema_registry_scraper_test.py
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/scrape/schema_registry_scraper_test.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from .. import test_utils
+
+from google.datacatalog_connectors.kafka.scrape.\
+    schema_registry_scraper import SchemaRegistryScraper
+from google.datacatalog_connectors.kafka.config import MetadataConstants
+
+
+class MetadataScraperTestCase(unittest.TestCase):
+
+    def test_scrape_schema_metadata_returns_metadata_dict(self):
+        schema_registry_client = test_utils.FakeKafkaSchemaRegistryClient()
+        scraper = SchemaRegistryScraper(schema_registry_client)
+        expected_metadata = {
+            MetadataConstants.TOPIC_KEY_SCHEMA: {
+                MetadataConstants.SCHEMA_TYPE: "AVRO",
+                MetadataConstants.SCHEMA_VERSION: 1,
+                MetadataConstants.SCHEMA_STRING:
+                    '{"type":"record","name":"updates", '
+                    '"fields":[{"name":"id","type":"string"},'
+                    '{"name":"degrees","type":"double"}]}'
+            },
+            MetadataConstants.TOPIC_VALUE_SCHEMA: {
+                MetadataConstants.SCHEMA_TYPE: "AVRO",
+                MetadataConstants.SCHEMA_VERSION: 1,
+                MetadataConstants.SCHEMA_STRING:
+                    '{"type":"record","name":"updates", '
+                    '"fields":[{"name":"id","type":"string"},'
+                    '{"name":"degrees","type":"double"}]}'
+            }
+        }
+        metadata = scraper.scrape_schema_metadata(topic_name="temperature")
+        self.maxDiff = None
+        self.assertEqual(metadata, expected_metadata)
+
+    def test_scrape_schema_metadata_with_no_valid_subjects(self):
+        schema_registry_client = test_utils.FakeKafkaSchemaRegistryClient()
+        scraper = SchemaRegistryScraper(schema_registry_client)
+        expected_metadata = {}
+        metadata = scraper.scrape_schema_metadata(topic_name="humidity")
+        self.assertEqual(metadata, expected_metadata)

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/sync/datacatalog_synchronizer_test.py
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/sync/datacatalog_synchronizer_test.py
@@ -87,8 +87,8 @@ class DatacatalogSynchronizerTestCase(unittest.TestCase):
             DatacatalogSynchronizerTestCase.__LOCATION_ID,
             DatacatalogSynchronizerTestCase.__ENTRY_GROUP_ID,
             DatacatalogSynchronizerTestCase.__HOST,
-            connection_config,
             MetadataScraper,
+            connection_config,
             enable_monitoring=True)
 
         synchronizer.run()

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/sync/datacatalog_synchronizer_test.py
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/sync/datacatalog_synchronizer_test.py
@@ -77,9 +77,8 @@ class DatacatalogSynchronizerTestCase(unittest.TestCase):
         # Test that all synchronizer calls go through and it doesn't
         # break in the middle
         make_entries_from_cluster_metadata.return_value = [{}]
-        connection_config = {
-            'bootstrap.servers': DatacatalogSynchronizerTestCase.__HOST,
-            'group.id': 'test_group'
+        schema_registry_conf = {
+            'url': 'https://test_url',
         }
 
         synchronizer = datacatalog_synchronizer.DataCatalogSynchronizer(
@@ -88,7 +87,7 @@ class DatacatalogSynchronizerTestCase(unittest.TestCase):
             DatacatalogSynchronizerTestCase.__ENTRY_GROUP_ID,
             DatacatalogSynchronizerTestCase.__HOST,
             MetadataScraper,
-            connection_config,
+            schema_registry_conf,
             enable_monitoring=True)
 
         synchronizer.run()

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/test_data/test_metadata_one_topic.json
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/test_data/test_metadata_one_topic.json
@@ -15,8 +15,16 @@
       "max_compaction_lag": 9223372036854775807,
       "max_compaction_lag_text": "292471208y 247d 7h 12min 55sec 807.0ms",
       "cleanup_policy": "delete, compact",
-      "topic_key_schema": "{\"type\":\"record\",\"name\":\"updates\", \"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"degrees\",\"type\":\"double\"}]}",
-      "topic_value_schema": "{\"type\":\"record\",\"name\":\"updates\", \"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"degrees\",\"type\":\"double\"}]}"
+      "topic_key_schema":
+        {"schema_type": "AVRO",
+        "schema_version": 1,
+        "schema_string": "{\"type\":\"record\",\"name\":\"updates\", \"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"degrees\",\"type\":\"double\"}]}"
+        },
+      "topic_value_schema":
+        {"schema_type": "AVRO",
+        "schema_version": 1,
+        "schema_string": "{\"type\":\"record\",\"name\":\"updates\", \"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"degrees\",\"type\":\"double\"}]}"
+        }
     }
   ]
 }

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/test_data/test_metadata_one_topic.json
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/test_data/test_metadata_one_topic.json
@@ -14,7 +14,9 @@
       "min_compaction_lag_text": "200.0ms",
       "max_compaction_lag": 9223372036854775807,
       "max_compaction_lag_text": "292471208y 247d 7h 12min 55sec 807.0ms",
-      "cleanup_policy": "delete, compact"
+      "cleanup_policy": "delete, compact",
+      "topic_key_schema": "{\"type\":\"record\",\"name\":\"updates\", \"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"degrees\",\"type\":\"double\"}]}",
+      "topic_value_schema": "{\"type\":\"record\",\"name\":\"updates\", \"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"degrees\",\"type\":\"double\"}]}"
     }
   ]
 }

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/test_utils/__init__.py
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/test_utils/__init__.py
@@ -14,11 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .test_utils import FakeDataCatalogEntryFactory,\
-    FakeKafkaAdminClient, FakeKafkaAdminClientEmptyCluster,\
+from .test_utils import FakeDataCatalogEntryFactory, \
+    FakeKafkaSchemaRegistryClient, FakeKafkaAdminClient, \
+    FakeKafkaAdminClientEmptyCluster,\
     get_test_topic_entry, get_test_cluster_entry,\
     mock_parse_args
 
 __all__ = ('FakeDataCatalogEntryFactory', 'FakeKafkaAdminClient',
-           'get_test_topic_entry', 'get_test_cluster_entry', 'mock_parse_args',
+           'FakeKafkaSchemaRegistryClient', 'get_test_topic_entry',
+           'get_test_cluster_entry', 'mock_parse_args',
            'FakeKafkaAdminClientEmptyCluster')

--- a/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/test_utils/test_utils.py
+++ b/google-datacatalog-kafka-connector/tests/google/datacatalog_connectors/kafka/test_utils/test_utils.py
@@ -20,6 +20,7 @@ from google.cloud import datacatalog_v1beta1
 from confluent_kafka.admin import ClusterMetadata, \
     TopicMetadata, BrokerMetadata, PartitionMetadata,\
     ConfigEntry, ConfigResource
+from confluent_kafka.schema_registry import Schema, RegisteredSchema
 from google.datacatalog_connectors.kafka.prepare.\
     datacatalog_entry_factory import DataCatalogEntryFactory
 
@@ -80,6 +81,23 @@ class FakeKafkaAdminClient(mock.MagicMock):
         return config_futures
 
 
+class FakeKafkaSchemaRegistryClient(mock.MagicMock):
+
+    def get_subjects(self):
+        return ["temperature-key", "temperature-value", "test-subject"]
+
+    def get_latest_version(self, subject_name):
+        test_schema_str = '{"type":"record","name":"updates", ' \
+                          '"fields":[{"name":"id","type":"string"},' \
+                          '{"name":"degrees","type":"double"}]}'
+        schema = Schema(test_schema_str, schema_type="AVRO")
+        registered_schema = RegisteredSchema(schema_id=1,
+                                             schema=schema,
+                                             subject=subject_name,
+                                             version=1)
+        return registered_schema
+
+
 def mock_parse_args():
     args = MockedObject()
     args.datacatalog_project_id = "project_id"
@@ -87,7 +105,11 @@ def mock_parse_args():
     args.datacatalog_entry_group_id = "kafka"
     args.kafka_host = "test_address"
     args.service_account_path = "path_to_service_account"
-    args.group_id = 'test_id'
+    args.schema_registry_url = "test_url"
+    args.schema_registry_ssl_ca_location = "test_ssl_ca_location"
+    args.schema_registry_ssl_cert_location = "test_ssl_cert_location"
+    args.schema_registry_ssl_key_location = "test_ssl_key_location"
+    args.schema_registry_auth_user_info = None
     args.enable_monitoring = True
     return args
 


### PR DESCRIPTION
This extension checks against Schema Registry and pulls the schemas for the topics, in case they are available.
It then adds a string representation of a schema to a tag field for the corresponding topic.
Example: https://screenshot.googleplex.com/BHieYK5uuAqQieN.png